### PR TITLE
Adds .NET Framework support

### DIFF
--- a/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
+++ b/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
@@ -63,10 +63,10 @@ namespace WkHtmlToPdfDotNet
             throw new NotSupportedException("Current platform is not supported");
         }
 
-        [DllImport(@"runtimes\win-x64\native\wkhtmltox", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl, EntryPoint = "wkhtmltopdf_version")]
+        [DllImport(@"runtimes\win-x64\native\wkhtmltox", CharSet = CharSet.Unicode, EntryPoint = "wkhtmltopdf_version")]
         public static extern IntPtr VersionWin64();
 
-        [DllImport(@"runtimes\win-x86\native\wkhtmltox", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl, EntryPoint = "wkhtmltopdf_version")]
+        [DllImport(@"runtimes\win-x86\native\wkhtmltox", CharSet = CharSet.Unicode, EntryPoint = "wkhtmltopdf_version")]
         public static extern IntPtr VersionWin86();
     }
 }

--- a/src/WkHtmlToPdf-DotNet/WkHtmlModule.cs
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlModule.cs
@@ -77,19 +77,19 @@ namespace WkHtmlToPdfDotNet
 
         const CharSet CHARSET = CharSet.Unicode;
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_extended_qt();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_version();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_init(int useGraphics);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_deinit();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_global_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -105,10 +105,10 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_global_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_object_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -124,59 +124,59 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_object_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_converter(IntPtr globalSettings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             byte[] data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             [MarshalAs((short)CustomUnmanagedType.LPUTF8Str)] string data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern bool wkhtmltopdf_convert(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_destroy_converter(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_get_output(IntPtr converter, out IntPtr data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_phase_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_progress_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_finished_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] IntCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_warning_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_error_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_phase_count(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_current_phase(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_phase_description(IntPtr converter, int phase);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_progress_string(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_http_error_code(IntPtr converter);
     }
 }

--- a/src/WkHtmlToPdf-DotNet/WkHtmlModuleLinux64.cs
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlModuleLinux64.cs
@@ -77,19 +77,19 @@ namespace WkHtmlToPdfDotNet
 
         const CharSet CHARSET = CharSet.Unicode;
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_extended_qt();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_version();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_init(int useGraphics);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_deinit();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_global_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -105,10 +105,10 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_global_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_object_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -124,59 +124,59 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_object_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_converter(IntPtr globalSettings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             byte[] data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             [MarshalAs((short)CustomUnmanagedType.LPUTF8Str)] string data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern bool wkhtmltopdf_convert(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_destroy_converter(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_get_output(IntPtr converter, out IntPtr data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_phase_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_progress_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_finished_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] IntCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_warning_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_error_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_phase_count(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_current_phase(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_phase_description(IntPtr converter, int phase);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_progress_string(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_http_error_code(IntPtr converter);
     }
 }

--- a/src/WkHtmlToPdf-DotNet/WkHtmlModuleLinux86.cs
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlModuleLinux86.cs
@@ -77,19 +77,19 @@ namespace WkHtmlToPdfDotNet
 
         const CharSet CHARSET = CharSet.Unicode;
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_extended_qt();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_version();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_init(int useGraphics);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_deinit();
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_global_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -105,10 +105,10 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_global_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_object_settings();
 
         [DllImport(DLLNAME, CharSet = CHARSET)]
@@ -124,59 +124,59 @@ namespace WkHtmlToPdfDotNet
             string name,
             IntPtr value, int valueSize);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_destroy_object_settings(IntPtr settings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_create_converter(IntPtr globalSettings);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             byte[] data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter,
             IntPtr objectSettings,
             [MarshalAs((short)CustomUnmanagedType.LPUTF8Str)] string data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern bool wkhtmltopdf_convert(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern void wkhtmltopdf_destroy_converter(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_get_output(IntPtr converter, out IntPtr data);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_phase_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_progress_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_finished_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] IntCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_warning_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_set_error_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_phase_count(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_current_phase(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_phase_description(IntPtr converter, int phase);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern IntPtr wkhtmltopdf_progress_string(IntPtr converter);
 
-        [DllImport(DLLNAME, CharSet = CHARSET, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(DLLNAME, CharSet = CHARSET)]
         public static extern int wkhtmltopdf_http_error_code(IntPtr converter);
     }
 }

--- a/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
@@ -1,58 +1,73 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <NoWarn>$(NoWarn);1591</NoWarn>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>WkHtmlToPdfDotNet</AssemblyName>
-    <PackageId>Haukcode.WkHtmlToPdfDotNet</PackageId>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.3.0</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>rdvojmoc, HakanL</Authors>
-    <RepositoryUrl>https://github.com/HakanL/WkHtmlToPdf-DotNet</RepositoryUrl>
-    <RepositoryType>Github</RepositoryType>
-    <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
-    <Description>.NET Core P/Invoke wrapper for wkhtmltopdf library that uses Webkit engine to convert HTML pages to PDF.</Description>
-    <PackageProjectUrl>https://github.com/HakanL/WkHtmlToPdf-DotNet</PackageProjectUrl>
-    <PackageReleaseNotes>1.3.0 Upgraded wkhtmltopdf to 0.12.6 and code refactoring
-1.2.0 Renamed project and namespace to Haukcode.WkHtmlToPdfDotNet</PackageReleaseNotes>
-    <PackageTags>wkhtmltopdf htmltopdf html pdf</PackageTags>
-    <RootNamespace>WkHtmlToPdfDotNet</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+		<AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<AssemblyName>WkHtmlToPdfDotNet</AssemblyName>
+		<PackageId>Haukcode.WkHtmlToPdfDotNet</PackageId>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<Version>1.3.0</Version>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Authors>rdvojmoc, HakanL</Authors>
+		<RepositoryUrl>https://github.com/HakanL/WkHtmlToPdf-DotNet</RepositoryUrl>
+		<RepositoryType>Github</RepositoryType>
+		<PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
+		<Description>.NET Core P/Invoke wrapper for wkhtmltopdf library that uses Webkit engine to convert HTML pages to PDF.</Description>
+		<PackageProjectUrl>https://github.com/HakanL/WkHtmlToPdf-DotNet</PackageProjectUrl>
+		<PackageReleaseNotes>
+			1.3.0 Upgraded wkhtmltopdf to 0.12.6 and code refactoring
+			1.2.0 Renamed project and namespace to Haukcode.WkHtmlToPdfDotNet
+		</PackageReleaseNotes>
+		<PackageTags>wkhtmltopdf htmltopdf html pdf</PackageTags>
+		<RootNamespace>WkHtmlToPdfDotNet</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove=".gitignore" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove=".gitignore" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="runtimes\linux-x64\native\libwkhtmltox.so" Pack="true" PackagePath="runtimes\linux-x64\native">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="runtimes\linux-x86\native\libwkhtmltox.so" Pack="true" PackagePath="runtimes\linux-x86\native">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="runtimes\osx-x64\native\libwkhtmltox.dylib" Pack="true" PackagePath="runtimes\osx-x64\native">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="runtimes\win-x64\native\wkhtmltox.dll" Pack="true" PackagePath="runtimes\win-x64\native">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="runtimes\win-x86\native\wkhtmltox.dll" Pack="true" PackagePath="runtimes\win-x86\native">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="build/Haukcode.WkHtmlToPdfDotNet.targets" PackagePath="build/Haukcode.WkHtmlToPdfDotNet.targets" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.Globalization" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="runtimes\linux-x64\native\libwkhtmltox.so" Pack="true" PackagePath="runtimes\linux-x64\native">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</None>
+		<None Include="runtimes\linux-x86\native\libwkhtmltox.so" Pack="true" PackagePath="runtimes\linux-x86\native">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</None>
+		<None Include="runtimes\osx-x64\native\libwkhtmltox.dylib" Pack="true" PackagePath="runtimes\osx-x64\native">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</None>
+		<None Include="runtimes\win-x64\native\wkhtmltox.dll" Pack="true" PackagePath="runtimes\win-x64\native">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</None>
+		<None Include="runtimes\win-x86\native\wkhtmltox.dll" Pack="true" PackagePath="runtimes\win-x86\native">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+		<PackageReference Include="System.Globalization" Version="4.3.0" />
+		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
+		<PackageReference Include="System.Runtime" Version="4.3.1" />
+		<PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Folder Include="build\" />
+	</ItemGroup>
 
 </Project>

--- a/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
+++ b/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<DllFiles Include="$(MSBuildThisFileDirectory)..\runtimes\**\win-*\**\*.*" />
+	</ItemGroup>
+	<Target Name="CopyDllFiles" BeforeTargets="Build">
+		<Copy SourceFiles="@(DllFiles)" DestinationFolder="$(TargetDir)\runtimes\%(RecursiveDir)" />
+	</Target>
+</Project>


### PR DESCRIPTION
This PR allows the wrapper to be used in projects targeting the full .NET Framework.

- When using `CallingConvention = CallingConvention.Cdecl`, PInvokeStackImbalance MDA (Managed Debugging Assistants) throws an exception on every P/Invoke call with the message: 
```
Managed Debugging Assistant 'PInvokeStackImbalance' 
A call to PInvoke function 'WkHtmlToPdfDotNet!WkHtmlToPdfDotNet.WkHtmlModule::wkhtmltopdf_init' has unbalanced the stack. 
This is likely because the managed PInvoke signature does not match the unmanaged target signature. 
Check that the calling convention and parameters of the PInvoke signature match the target unmanaged signature.
```
[This is not the case with .NET Core as the MDAs don't exist.](https://github.com/dotnet/runtime/issues/47826)

I replaced every `CallingConvention` with `CallingConvention.StdCall` (default), which was working fine on my environment (Windows, .NET Framework & Core) but it would be great if you could verify that it's working on every other environment as excepted as well. :smile:

- An extra [src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets](https://github.com/HakanL/WkHtmlToPdf-DotNet/compare/master...georgechond94:dotnet-framework-support?expand=1#diff-95abb23e6317851493f94047eccf1ea365bb6ec999a76ac42bbec27f1191a6b4) added which should copy the `/runtimes/win-x` DLLs to the output folder of the referencing application on build, as I couldn't make it to work the same way it does on .NET Core.
Current integration with .NET Core isn't affected by that.

Closes: #33, #28 (?)