### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,9 @@ public void ConfigureServices(IServiceCollection services)
     services.AddSingleton(typeof(IConverter), new SynchronizedConverter(new PdfTools()));
 }
 ```
+
+### Docker 
+If you are using the linux version of docker container for net core provided from microsoft, you need to add this line to the dockerfile 
+```
+RUN apt-get update -qq && apt-get -y install libgdiplus libc6-dev
+```


### PR DESCRIPTION
This change might be helpful as by default the docker container doesn't contain the necessary dependencies of wkhtmltox