### PR TITLE
Update nuget to work with AnyCPU .net platform builds

### DIFF
--- a/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
+++ b/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
@@ -15,7 +15,7 @@ namespace WkHtmlToPdfDotNet
             catch
             {
             }
-
+#if NETSTANDARD2_0
             // Windows allows us to probe for either 64 or 86 bit versions
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -59,7 +59,7 @@ namespace WkHtmlToPdfDotNet
                 {
                 }
             }
-
+#endif
             throw new NotSupportedException("Unable to load native library. The platform may be missing native dependencies (libjpeg62, etc). Or the current platform is not supported.");
         }
 

--- a/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
@@ -70,5 +70,4 @@
 	<ItemGroup>
 		<Folder Include="build\" />
 	</ItemGroup>
-
 </Project>

--- a/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
+++ b/src/WkHtmlToPdf-DotNet/WkHtmlToPdf-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<AllowUnsafeBlocks>false</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
+++ b/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
@@ -6,4 +6,17 @@
 	<Target Name="CopyDllFiles" BeforeTargets="Build">
 		<Copy SourceFiles="@(DllFiles)" DestinationFolder="$(TargetDir)\runtimes\%(RecursiveDir)" />
 	</Target>
+	<ItemGroup Condition=" '$(Platform)' == 'x64' ">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\wkhtmltox.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>wkhtmltox.dll</Link>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU' ">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\wkhtmltox.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>wkhtmltox.dll</Link>
+		</Content>
+	</ItemGroup>
 </Project>

--- a/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
+++ b/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
@@ -6,7 +6,7 @@
 	<Target Name="CopyDllFiles" BeforeTargets="Build">
 		<Copy SourceFiles="@(DllFiles)" DestinationFolder="$(TargetDir)\runtimes\%(RecursiveDir)" />
 	</Target>
-	<ItemGroup Condition=" '$(Platform)' == 'x64' ">
+		<ItemGroup Condition=" '$(Platform)' == 'x64' ">
 		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\wkhtmltox.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Link>wkhtmltox.dll</Link>


### PR DESCRIPTION
I've tested these changes locally by deploying to an internal nuget feed and consuming the new nuget package in a .net472 64bit app running in asp.net and it worked.

With the original package it failed on the convert with "platform not supported" error.