### PR TITLE
Include both 32 bit and 64 bit runtimes in .NET Framework builds

### DIFF
--- a/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
+++ b/src/WkHtmlToPdf-DotNet/ModuleFactory.cs
@@ -7,18 +7,11 @@ namespace WkHtmlToPdfDotNet
     {
         public static IWkHtmlModule GetModule()
         {
-            // First try the method used by the NuGet package (which uses the deps file)
-            try
-            {
-                return new WkHtmlModule();
-            }
-            catch
-            {
-            }
 #if NETSTANDARD2_0
             // Windows allows us to probe for either 64 or 86 bit versions
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+# endif
                 try
                 {
                     // Try 64-bit
@@ -40,7 +33,8 @@ namespace WkHtmlToPdfDotNet
                 catch
                 {
                 }
-            }
+#if NETSTANDARD2_0
+        }
             else
             {
                 try

--- a/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
+++ b/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
@@ -6,17 +6,20 @@
 	<Target Name="CopyDllFiles" BeforeTargets="Build">
 		<Copy SourceFiles="@(DllFiles)" DestinationFolder="$(TargetDir)\runtimes\%(RecursiveDir)" />
 	</Target>
-		<ItemGroup Condition=" '$(Platform)' == 'x64' ">
-		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\wkhtmltox.dll">
+
+	<ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\wkhtmltox.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<Link>wkhtmltox.dll</Link>
-		</Content>
+			<Link>runtimes\win-x64\native\wkhtmltox.dll</Link>
+			<Visible>false</Visible>
+		</None>
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU' ">
-		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\wkhtmltox.dll">
+	<ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\wkhtmltox.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<Link>wkhtmltox.dll</Link>
-		</Content>
+			<Link>runtimes\win-x86\native\wkhtmltox.dll</Link>
+			<Visible>false</Visible>
+		</None>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the build process to copy both x86 and x64 runtimes when building .NET Framework projects. Having only the x86 DLL linked in the project root does not work for AnyCPU assemblies that can run in both 32 bit and 64 bit and needs the proper version of the DLL.

Instead the runtimes folder is copied with only win-x86 and win-x64 runtimes (the others platforms are not supported by .NET Framework)

I believe this will fix issue #58