### PR TITLE
Reduce package size by copying correct native dlls 

### DIFF
--- a/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
+++ b/src/WkHtmlToPdf-DotNet/build/Haukcode.WkHtmlToPdfDotNet.targets
@@ -7,7 +7,7 @@
 		<Copy SourceFiles="@(DllFiles)" DestinationFolder="$(TargetDir)\runtimes\%(RecursiveDir)" />
 	</Target>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU' ">
 		<None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\wkhtmltox.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Link>runtimes\win-x64\native\wkhtmltox.dll</Link>
@@ -15,7 +15,7 @@
 		</None>
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU' ">
 		<None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\wkhtmltox.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Link>runtimes\win-x86\native\wkhtmltox.dll</Link>


### PR DESCRIPTION
To reduce the final package size copy include the native dlls as following:

- "AnyCPU" copy both native dlls (x86, x64)
- "x64" copy only x64 native dll
- "x86" copy only x86 native dll